### PR TITLE
Integrate google analytics baby 🤘

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,17 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>match.</title>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163693054-3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-163693054-3');
+    </script>
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Simply adding this little gtag to index.html allows us to integrate google analytics (see user data, acquisition channels, etc.)

Once this PR is merged, you will be able to check [the dashboard](https://analytics.google.com/analytics/web/?authuser=2#/report-home/a163693054w247595779p229853020) to see how many people are visiting match, what location they're from, whole lotta ethically questionable shit.

Note: To see the dashboard, you will have to login to the team.riceapps@gmail.com email. I think zawie has access.

Ping me if you have q's as usual